### PR TITLE
Fix multi-line message support #32

### DIFF
--- a/wp-git-sync.sh
+++ b/wp-git-sync.sh
@@ -59,7 +59,7 @@ while :; do
             ;;
         -m|--message) #optional
             if [[ $2 ]]; then
-                MESSAGE=$2
+                MESSAGE="$2"
                 shift
             else
                 ERRORMESSAGES="ERROR: '-m | --message' requires a non-empty option argument."


### PR DESCRIPTION
This should fix the multi-line issue.

I'd also recommend using https://www.shellcheck.net/, and perhaps even just plain `/bin/sh` (`[ -n "$2" ]` instead of `[[ "$2" ]]`, `[ x = y ]` instead of `[ x == y ]`). Plain shell only gets one array but that's fine.

Let me know if you'd like a conversion~